### PR TITLE
Give MANAGE_CHANNELS permission to voice channel creators

### DIFF
--- a/src/functions/voiceChannelManagement.ts
+++ b/src/functions/voiceChannelManagement.ts
@@ -52,12 +52,14 @@ export const createVoiceChannelForMember = (state: VoiceState) => {
             //permissions
             permissionOverwrites: [
                 //allow user to move members out of this channel
+                //note: MANAGE_CHANNELS as a permission overwrite on a single channel doesn't extend to the entire guild
                 {
                     id: user?.id!,
                     allow: [
                         Permissions.MOVE,
                         Permissions.MUTE,
-                        Permissions.DEAFEN
+                        Permissions.DEAFEN,
+                        Permissions.MANAGE_CHANNELS
                     ]
                 }
             ]

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -51,7 +51,8 @@ export module VoiceConstants {
     export const enum Permissions {
         MOVE = 'MOVE_MEMBERS',
         MUTE = 'MUTE_MEMBERS',
-        DEAFEN = 'DEAFEN_MEMBERS'
+        DEAFEN = 'DEAFEN_MEMBERS',
+        MANAGE_CHANNELS = 'MANAGE_CHANNELS'
     }
 }
 


### PR DESCRIPTION
FYI: MANAGE_CHANNELS as a permission overwrite on a single channel doesn't extend to the entire guild, it only affects that one channel.