### PR TITLE
Move channel name badness to IDs to prevent similar thread names from causing chaos

### DIFF
--- a/src/commands/rantChannelCommands.ts
+++ b/src/commands/rantChannelCommands.ts
@@ -1,5 +1,6 @@
 import { Client, Message, TextChannel } from 'discord.js';
 import { each } from 'underscore';
+import { ChannelIds } from '../utils/constants';
 
 export const deleteMessages = async (message: Message) => {
     try {
@@ -19,7 +20,7 @@ export const deleteMessages = async (message: Message) => {
 
 export const clearChannel = async (client: Client) => {
     each(client.guilds.cache.array(), async (guild) => {
-        const rantChannel = guild.channels.cache.find(ch => ch.name == 'rant') as TextChannel;
+        const rantChannel = guild.channels.cache.find(ch => ch.id == ChannelIds.RANT) as TextChannel;
         const last = await rantChannel.messages.fetch({ limit: 1 });
         if (!last.array()?.[0]) {
             return;

--- a/src/functions/voiceChannelManagement.ts
+++ b/src/functions/voiceChannelManagement.ts
@@ -1,16 +1,15 @@
 import { VoiceState } from "discord.js";
-import { Environment, VoiceConstants } from "../utils/constants";
+import { ChannelIds, Environment, VoiceConstants } from "../utils/constants";
 
 const { Permissions } = VoiceConstants;
 
 export const handleVoiceStatusUpdate = (oldState: VoiceState, newState: VoiceState) => {
-    const groupName = 'user-voice-channels'
 
     // check for bot
     if (oldState?.member?.user?.bot) return;
 
     // if user has joined the test channel, do the thing
-    if (newState?.member?.voice?.channel?.name == 'Join to create channel') {
+    if (newState?.member?.voice?.channel?.id == ChannelIds.VOICE_CREATE) {
         createVoiceChannelForMember(newState);
     }
     // if user has left a channel (no newstate.voiceChannel), delete it if it's empty
@@ -22,9 +21,9 @@ export const handleVoiceStatusUpdate = (oldState: VoiceState, newState: VoiceSta
             newState?.channelID != oldState?.channelID
         ) &&
         //and you're not leaving the initial join channel
-        oldState?.channel?.name != 'Join to create channel' &&
+        oldState?.channel?.id != ChannelIds.VOICE_CREATE &&
         //and you ARE leaving a channel in the group
-        oldState?.channel?.parent?.name == groupName
+        oldState?.channel?.parent?.id == ChannelIds.USER_VOICE_GROUP
     ) {
         // THEN delete the old channel
         deleteEmptyMemberVoiceChannel(oldState)
@@ -38,7 +37,7 @@ export const createVoiceChannelForMember = (state: VoiceState) => {
     }
     const user = guild.member(state.member?.user!);
     const user_channel_name = `${user?.nickname ?? user?.user.username}'s voice chat`;
-    const category_channel = guild.channels.cache.find(channel => channel.name === VoiceConstants.groupName);
+    const category_channel = guild.channels.cache.find(channel => channel.id === ChannelIds.USER_VOICE_GROUP);
     // find channel group
     if (category_channel) {
 
@@ -71,7 +70,7 @@ export const createVoiceChannelForMember = (state: VoiceState) => {
 };
 
 export const deleteEmptyMemberVoiceChannel = (state: VoiceState) => {
-    if (state?.channel?.members?.array()?.length == 0 && state?.channel?.parent?.name == VoiceConstants.groupName) {
+    if (state?.channel?.members?.array()?.length == 0 && state?.channel?.parent?.id == ChannelIds.USER_VOICE_GROUP) {
         state?.channel?.delete();
     }
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { Config, Environment } from './utils/constants';
+import { ChannelIds, Config, Environment } from './utils/constants';
 import { Command } from './models/Command';
 import { schedule } from 'node-cron';
 import { Client, TextChannel } from 'discord.js'
@@ -55,7 +55,7 @@ client.on('guildMemberAdd', newAccountJoins);
 
 //handle messages
 client.on('message', async (message) => {
-    if (message.channel instanceof TextChannel && message?.channel?.name == 'rant') {
+    if (message.channel instanceof TextChannel && message?.channel?.id == ChannelIds.RANT) {
         deleteMessages(message);
         return;
     }
@@ -103,7 +103,7 @@ client.on('ready', async () => {
     if (DEBUG) {
         //try to announce to servers when you go online
         each(client.guilds.cache.array(), (guild) => {
-            const debugChannel = guild.channels.cache.find(ch => ch.name == 'debug') as TextChannel;
+            const debugChannel = guild.channels.cache.find(ch => ch.id == ChannelIds.DEBUG) as TextChannel;
             debugChannel && debugChannel.send("SEAbot online!");
         });
     }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,6 +15,13 @@ export module Config {
     export const prefix = '$';
 }
 
+export module ChannelIds {
+    export const RANT = '804639001226379294';
+    export const VOICE_CREATE = '788552426906845185';
+    export const USER_VOICE_GROUP = '788552301182320640';
+    export const DEBUG = '541322708844281867';
+}
+
 export module AppConfiguration {
     export const BOT_RELEASE_VERSION = process.env['botReleaseVersion'] || undefined;
     export const BOT_RELEASE_REASON = process.env['botReleaseReason'] || undefined;


### PR DESCRIPTION
Not sure if threads will show up in a cache search for channels by name but... this should avoid it regardless