### PR TITLE
Initial implementation of `days since last incident` tracker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@azure/cosmos": "^3.15.1",
         "@discordjs/builders": "^0.8.2",
         "@discordjs/opus": "^0.3.3",
         "@discordjs/rest": "^0.1.0-canary.0",
@@ -31,6 +32,129 @@
         "@types/node-hue-api": "^2.3.2",
         "@types/underscore": "^1.11.0",
         "typescript": "^4.3.5"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
+      "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
+      "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.4.0.tgz",
+      "integrity": "sha512-M2uL9PbvhJIEMRoUad3EnXCHWLN/i0W7D7MQJ9rnIDW7iLVCteUiegdqNa2Cr1/7he/ysEXYiwaXiHmfack/6g==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/logger": "^1.0.0",
+        "form-data": "^4.0.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "tslib": "^2.2.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.0.0-preview.13",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+      "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.1",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/cosmos": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.15.1.tgz",
+      "integrity": "sha512-Pjn9CcoipUSsm/r9ZqAeyrqIQnh0AOeIDwYs/3pcLumK9ezCVFrfeLoOfas4Dm2X8bwL+/9puKAM55LJEaQwWg==",
+      "dependencies": {
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.2.0",
+        "debug": "^4.1.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "jsbi": "^3.1.3",
+        "node-abort-controller": "^3.0.0",
+        "priorityqueuejs": "^1.0.0",
+        "semaphore": "^1.0.5",
+        "tslib": "^2.2.0",
+        "universal-user-agent": "^6.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/cosmos/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@azure/cosmos/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/@azure/cosmos/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
+      "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -111,6 +235,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@peter-murray/hue-bridge-model": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@peter-murray/hue-bridge-model/-/hue-bridge-model-2.0.3.tgz",
@@ -147,6 +279,14 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@types/body-parser": {
@@ -311,6 +451,38 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -949,6 +1121,40 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -962,6 +1168,39 @@
         "node": ">=0.8",
         "npm": ">=1.3.7"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -1042,6 +1281,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "node_modules/jsbi": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz",
+      "integrity": "sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ=="
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
@@ -1274,6 +1518,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
+    },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
@@ -1480,6 +1729,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "node_modules/priorityqueuejs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
+      "integrity": "sha1-LuTyPCVgkT4IwHzlzN1t498sWvg="
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -1708,6 +1962,14 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "node_modules/semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.3.5",
@@ -1984,6 +2246,11 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
       "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2118,6 +2385,101 @@
     }
   },
   "dependencies": {
+    "@azure/abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
+      "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@azure/core-auth": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
+      "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@azure/core-rest-pipeline": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.4.0.tgz",
+      "integrity": "sha512-M2uL9PbvhJIEMRoUad3EnXCHWLN/i0W7D7MQJ9rnIDW7iLVCteUiegdqNa2Cr1/7he/ysEXYiwaXiHmfack/6g==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/logger": "^1.0.0",
+        "form-data": "^4.0.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "tslib": "^2.2.0",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.0.0-preview.13",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+      "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
+      "requires": {
+        "@opentelemetry/api": "^1.0.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@azure/cosmos": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.15.1.tgz",
+      "integrity": "sha512-Pjn9CcoipUSsm/r9ZqAeyrqIQnh0AOeIDwYs/3pcLumK9ezCVFrfeLoOfas4Dm2X8bwL+/9puKAM55LJEaQwWg==",
+      "requires": {
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.2.0",
+        "debug": "^4.1.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "jsbi": "^3.1.3",
+        "node-abort-controller": "^3.0.0",
+        "priorityqueuejs": "^1.0.0",
+        "semaphore": "^1.0.5",
+        "tslib": "^2.2.0",
+        "universal-user-agent": "^6.0.0",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@azure/logger": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
+      "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
     "@discordjs/builders": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.8.2.tgz",
@@ -2183,6 +2545,11 @@
         }
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog=="
+    },
     "@peter-murray/hue-bridge-model": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@peter-murray/hue-bridge-model/-/hue-bridge-model-2.0.3.tgz",
@@ -2202,6 +2569,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
       "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+    },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -2357,6 +2729,29 @@
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
+      }
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "ajv": {
@@ -2861,6 +3256,31 @@
         "toidentifier": "1.0.1"
       }
     },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2869,6 +3289,30 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "iconv-lite": {
@@ -2938,6 +3382,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbi": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz",
+      "integrity": "sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ=="
     },
     "jsbn": {
       "version": "0.1.1",
@@ -3118,6 +3567,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
+    },
     "node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
@@ -3274,6 +3728,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "priorityqueuejs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
+      "integrity": "sha1-LuTyPCVgkT4IwHzlzN1t498sWvg="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -3442,6 +3901,11 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
     },
     "semver": {
       "version": "7.3.5",
@@ -3654,6 +4118,11 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
       "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "a bot. in SEA.",
   "main": "dist/server.js",
   "dependencies": {
+    "@azure/cosmos": "^3.15.1",
     "@discordjs/builders": "^0.8.2",
     "@discordjs/opus": "^0.3.3",
     "@discordjs/rest": "^0.1.0-canary.0",

--- a/src/commands/databaseCommands.ts
+++ b/src/commands/databaseCommands.ts
@@ -1,0 +1,108 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { Message, CommandInteraction, MessageEmbed } from "discord.js";
+import { format } from "path";
+import DBConnector from "../db/DBConnector";
+import { Command } from "../models/Command";
+import { Award } from "../models/DBModels";
+import { Database } from "../utils/constants";
+
+export class GiveAwardCommand implements Command {
+    private connector: DBConnector<Award>;
+    name: string = 'award';
+    adminOnly = false;
+    constructor(connector: DBConnector<Award>) {
+        this.connector = connector;
+    }
+    description = 'Give another user an award';
+    help = 'award user message';
+    execute = (message: Message<boolean>, args?: string[] | undefined) => {
+        return;
+    }
+    slashCommandDescription = () => {
+        return new SlashCommandBuilder()
+            .setName('award')
+            .setDescription('give another user an award')
+            .addUserOption(option => {
+                return option
+                    .setName('user')
+                    .setDescription('who are you awarding')
+                    .setRequired(true);
+            })
+            .addStringOption(option => {
+                return option
+                    .setName('message')
+                    .setDescription('let them know what they did to deserve it!')
+                    .setRequired(false);
+            })
+
+    };
+    executeSlashCommand = async (interaction: CommandInteraction) => {
+        await interaction.deferReply({ephemeral: true});
+        const user = interaction.options.getUser('user', true);
+        if(user.id == interaction.user.id) {
+            await interaction.followUp({ content: 'Try giving someone else an award, maybe?', ephemeral: true});
+            return;
+        }
+        const message = interaction.options.getString('message', false);
+        const award: Award = {
+            awardedBy: interaction.user.id,
+            awardedTo: user.id,
+            awardedOn: new Date,
+            message: message ?? undefined
+        }
+        const result = await this.connector.addItem(award);
+        if(result?.id) {
+            await interaction.followUp({content: 'Award granted!', ephemeral: true});
+        }
+        // interaction.guild?.systemChannel?.send(`${user.username} has been given an award!`)
+    }
+}
+
+export class ShowAwardsCommand implements Command {
+    private connector: DBConnector<Award>;
+    name: string = 'awards';
+    adminOnly = false;
+    constructor(connector: DBConnector<Award>) {
+        this.connector = connector;
+    }
+    description = 'Show awards (for yourself or another user)';
+    help = 'awards [user]';
+    execute = (message: Message<boolean>, args?: string[] | undefined) => {
+        return;
+    }
+    slashCommandDescription = () => {
+        return new SlashCommandBuilder()
+            .setName('awards')
+            .setDescription('show your awards (or another user\'s)')
+            .addUserOption(option => {
+                return option
+                    .setName('user')
+                    .setDescription('who are you awarding')
+                    .setRequired(false);
+            })
+
+    };
+    executeSlashCommand = async (interaction: CommandInteraction) => {
+        await interaction.deferReply({ephemeral: true});
+        const user = interaction.options.getUser('user', false);
+        const records = await this.connector.find(Database.Queries.AWARDS_BY_USER(user ? user.id : interaction.user.id));
+        if(records?.[0]) {
+            const embed = new MessageEmbed({
+                title: `Awards for ${user?.username || interaction.user.username}`,
+                description: `${records.length} award${records.length > 1 ? 's' : ''}:`,
+                fields: records.map((award, i) => {
+                    return {
+                        name: `${i+1}: ${award.message || 'No message'}`,
+                        value: award.awardedOn.toString()
+                    }
+                })
+            });
+            await interaction.followUp({embeds: [embed]});
+        }
+        else{
+            await interaction.followUp({content: 'No awards found', ephemeral: true})
+        }
+        
+    }
+}
+

--- a/src/commands/databaseCommands.ts
+++ b/src/commands/databaseCommands.ts
@@ -1,108 +1,195 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { Message, CommandInteraction, MessageEmbed } from "discord.js";
-import { format } from "path";
+import { Message, CommandInteraction, MessageEmbed, GuildMemberRoleManager } from "discord.js";
 import DBConnector from "../db/DBConnector";
 import { Command } from "../models/Command";
-import { Award } from "../models/DBModels";
-import { Database } from "../utils/constants";
+import { Award, Incident } from "../models/DBModels";
+import { Database, RoleIds } from "../utils/constants";
 
-export class GiveAwardCommand implements Command {
+
+// #region awards
+
+enum AwardSubCommandType {
+    GIVE = 'give',
+    LIST = 'list'
+}
+export class AwardsCommand implements Command {
     private connector: DBConnector<Award>;
     name: string = 'award';
-    adminOnly = false;
+    adminOnly = true;
     constructor(connector: DBConnector<Award>) {
         this.connector = connector;
     }
     description = 'Give another user an award';
-    help = 'award user message';
+    help = 'award user message | award user list';
     execute = (message: Message<boolean>, args?: string[] | undefined) => {
+        // will not implement, slash commands are cooler
         return;
     }
     slashCommandDescription = () => {
-        return new SlashCommandBuilder()
+        const cmd = new SlashCommandBuilder()
             .setName('award')
-            .setDescription('give another user an award')
-            .addUserOption(option => {
-                return option
-                    .setName('user')
-                    .setDescription('who are you awarding')
-                    .setRequired(true);
+            .setDescription('Give and list awards')
+            .setDefaultPermission(false);
+            cmd.addSubcommand(cmd => {
+                return cmd
+                .setName(AwardSubCommandType.GIVE)
+                .setDescription('give another user an award')
+                .addUserOption(option => {
+                    return option
+                        .setName('user')
+                        .setDescription('who are you awarding')
+                        .setRequired(true);
+                })
+                .addStringOption(option => {
+                    return option
+                        .setName('message')
+                        .setDescription('let them know what they did to deserve it!')
+                        .setRequired(false);
+                });
             })
-            .addStringOption(option => {
-                return option
-                    .setName('message')
-                    .setDescription('let them know what they did to deserve it!')
-                    .setRequired(false);
-            })
+            .addSubcommand(cmd => {
+                return cmd
+                .setName(AwardSubCommandType.LIST)
+                .setDescription('show your awards (or another user\'s)')
+                .addUserOption(option => {
+                    return option
+                        .setName('user')
+                        .setDescription('who are you awarding')
+                        .setRequired(false);
+                });
+            });
+            return cmd;
 
     };
     executeSlashCommand = async (interaction: CommandInteraction) => {
         await interaction.deferReply({ephemeral: true});
-        const user = interaction.options.getUser('user', true);
-        if(user.id == interaction.user.id) {
-            await interaction.followUp({ content: 'Try giving someone else an award, maybe?', ephemeral: true});
-            return;
+        const cmd = interaction.options.getSubcommand(true);
+        if(cmd === AwardSubCommandType.GIVE) {
+            const user = interaction.options.getUser('user', true);
+            if(user.id == interaction.user.id) {
+                await interaction.followUp({ content: 'Try giving someone else an award, maybe?', ephemeral: true});
+                return;
+            }
+            const message = interaction.options.getString('message', false);
+            const award: Award = {
+                awardedBy: interaction.user.id,
+                awardedTo: user.id,
+                awardedOn: new Date,
+                message: message ?? undefined
+            }
+            const result = await this.connector.addItem(award);
+            if(result?.id) {
+                await interaction.followUp({content: 'Award granted!', ephemeral: true});
+            }
+            // interaction.guild?.systemChannel?.send(`${user.username} has been given an award!`)
         }
-        const message = interaction.options.getString('message', false);
-        const award: Award = {
-            awardedBy: interaction.user.id,
-            awardedTo: user.id,
-            awardedOn: new Date,
-            message: message ?? undefined
+        else if(cmd === AwardSubCommandType.LIST) {
+            const user = interaction.options.getUser('user', false);
+            const records = await this.connector.find(Database.Queries.AWARDS_BY_USER(user ? user.id : interaction.user.id));
+            if(records?.[0]) {
+                const embed = new MessageEmbed({
+                    title: `Awards for ${user?.username || interaction.user.username}`,
+                    description: `${records.length} award${records.length > 1 ? 's' : ''}:`,
+                    fields: records.map((award, i) => {
+                        return {
+                            name: `${i+1}: ${award.message || 'No message'}`,
+                            value: award.awardedOn.toString()
+                        }
+                    })
+                });
+                await interaction.followUp({embeds: [embed]});
+            }
+            else{
+                await interaction.followUp({content: 'No awards found', ephemeral: true})
+            }
         }
-        const result = await this.connector.addItem(award);
-        if(result?.id) {
-            await interaction.followUp({content: 'Award granted!', ephemeral: true});
-        }
-        // interaction.guild?.systemChannel?.send(`${user.username} has been given an award!`)
     }
 }
 
-export class ShowAwardsCommand implements Command {
-    private connector: DBConnector<Award>;
-    name: string = 'awards';
-    adminOnly = false;
-    constructor(connector: DBConnector<Award>) {
+// #endregion
+
+// #region incidents
+enum IncidentSubCommandTypes {
+    LAST = 'last',
+    NEW = 'new'
+}
+export class IncidentCommand implements Command {
+    private connector: DBConnector<Incident>;
+    name: string = 'incident';
+    constructor(connector: DBConnector<Incident>) {
         this.connector = connector;
     }
-    description = 'Show awards (for yourself or another user)';
-    help = 'awards [user]';
+    description = 'How many days since our last incident?';
+    help = 'incident';
     execute = (message: Message<boolean>, args?: string[] | undefined) => {
+        // will not implement, slash commands are cooler
         return;
     }
     slashCommandDescription = () => {
-        return new SlashCommandBuilder()
-            .setName('awards')
-            .setDescription('show your awards (or another user\'s)')
-            .addUserOption(option => {
-                return option
-                    .setName('user')
-                    .setDescription('who are you awarding')
-                    .setRequired(false);
-            })
-
+        const cmd = new SlashCommandBuilder()
+            .setName('incident')
+            .setDescription('check how many days have passed since our last `incident`')
+        cmd.addSubcommand(cmd =>
+            cmd.setName('last')
+            .setDescription('days since last `incident`')
+        )
+        .addSubcommand(cmd =>
+            cmd.setName('new')
+            .setDescription('indicates that a new incident has occurred')
+            .addStringOption(option => option.setName('note').setDescription('what went down'))
+        )
+        return cmd;
     };
     executeSlashCommand = async (interaction: CommandInteraction) => {
-        await interaction.deferReply({ephemeral: true});
-        const user = interaction.options.getUser('user', false);
-        const records = await this.connector.find(Database.Queries.AWARDS_BY_USER(user ? user.id : interaction.user.id));
-        if(records?.[0]) {
-            const embed = new MessageEmbed({
-                title: `Awards for ${user?.username || interaction.user.username}`,
-                description: `${records.length} award${records.length > 1 ? 's' : ''}:`,
-                fields: records.map((award, i) => {
-                    return {
-                        name: `${i+1}: ${award.message || 'No message'}`,
-                        value: award.awardedOn.toString()
-                    }
-                })
+        const cmd = interaction.options.getSubcommand(true);
+        if(cmd === IncidentSubCommandTypes.LAST) {
+            //not a private response
+            await interaction.deferReply({ephemeral: false});
+            // find the last incident
+            const incident = await this.connector.getLastItem();
+            if(!incident) {
+                // uh, we got a problem
+                interaction.followUp({content: 'No incidents yet. Hmm...', ephemeral: true});
+                return;
+            }
+            // do some math
+            const timeSince = Date.now() - new Date(incident?.occurrence).getTime();
+            const daysSince = timeSince / (1000 * 60 * 60 * 24);
+            // tell everyone
+            interaction.followUp({
+                content: `It has been ${Math.round(daysSince)} day${daysSince > 1 ? 's' : ''} since the last incident.\n***${incident.note ?? 'No note provided for this incident.'}***`,
+                ephemeral: false
             });
-            await interaction.followUp({embeds: [embed]});
+        }
+        else if(cmd === IncidentSubCommandTypes.NEW) {
+            // private response
+            await interaction.deferReply({ephemeral: true});
+            // make sure the user is allowed
+            const { member } = interaction;
+            if((member?.roles as GuildMemberRoleManager).cache.has(RoleIds.MOD)) {
+                //create a new incident
+                const incident: Incident = {
+                    occurrence: new Date(),
+                    note: interaction.options.getString('note') ?? undefined
+                }
+                const result = await this.connector.addItem(incident);
+                if(result){
+                    //make a statement confirming db transaction
+                    interaction.followUp(`Created incident id ${result.id}: ${result.note} at ${result.occurrence}`);
+                    //let everyone know we've reset to 0
+                    interaction.guild?.systemChannel?.send(`Congratulations! It has now been \`0\` days since our last incident!\n***${result.note}***`);
+                }
+                else {
+                    interaction.followUp('Error creating incident record');
+                }
+            }
+            else {
+                interaction.followUp('You cannot perform this action. Ping a mod');
+            }
         }
         else{
-            await interaction.followUp({content: 'No awards found', ephemeral: true})
+            interaction.followUp('Subcommand required. RTFM');
         }
-        
     }
 }
-
+// #endregion

--- a/src/commands/databaseCommands.ts
+++ b/src/commands/databaseCommands.ts
@@ -135,6 +135,7 @@ export class IncidentCommand implements Command {
         .addSubcommand(cmd =>
             cmd.setName('new')
             .setDescription('indicates that a new incident has occurred')
+            .addStringOption(option => option.setName('link').setDescription('message link to start of incident'))
             .addStringOption(option => option.setName('note').setDescription('what went down'))
         )
         return cmd;
@@ -156,7 +157,7 @@ export class IncidentCommand implements Command {
             const daysSince = timeSince / (1000 * 60 * 60 * 24);
             // tell everyone
             interaction.followUp({
-                content: `It has been ${Math.round(daysSince)} day${daysSince > 1 ? 's' : ''} since the last incident.\n***${incident.note ?? 'No note provided for this incident.'}***`,
+                content: `It has been ${Math.round(daysSince)} day${daysSince > 1 ? 's' : ''} since the last incident.\n***${incident.note ?? 'No note provided for this incident.'}***${incident.link ? `\n${incident.link}` : ``}`,
                 ephemeral: false
             });
         }
@@ -178,7 +179,7 @@ export class IncidentCommand implements Command {
                     //make a statement confirming db transaction
                     interaction.followUp(`Created incident id ${result.id}: ${result.note} at ${result.occurrence}`);
                     //let everyone know we've reset to 0
-                    interaction.guild?.systemChannel?.send(`Congratulations! It has now been \`0\` days since our last incident!\n***${result.note}***`);
+                    interaction.guild?.systemChannel?.send(`Congratulations! It has now been \`0\` days since our last incident!\n***${result.note ?? 'No note provided for this incident.'}***${result.link ? `\n${result.link}` : ``}`);
                 }
                 else {
                     // db transaction failed

--- a/src/db/DBConnector.ts
+++ b/src/db/DBConnector.ts
@@ -1,5 +1,5 @@
 // @ts-check
-import { Container, CosmosClient, Database, Resource, SqlQuerySpec } from "@azure/cosmos"
+import { Container, CosmosClient, Database, SqlQuerySpec } from "@azure/cosmos"
 
 export default class DBConnector<T> {
 
@@ -40,7 +40,7 @@ export default class DBConnector<T> {
       throw new Error('Collection is not initialized.')
     }
     const { resources } = await this.container.items.query<T>(querySpec).fetchAll()
-    return resources
+    return resources;
   }
 
   async addItem(item: T) {
@@ -55,8 +55,8 @@ export default class DBConnector<T> {
     if (!this.container) {
       throw new Error('Collection is not initialized.')
     }
-    const { resource } = await this.container.item(itemId).read<T>()
-    return resource
+    const { resource } = await this.container.item(itemId).read<T>();
+    return resource;
   }
   
   async deleteItem(itemId: string) {
@@ -65,5 +65,13 @@ export default class DBConnector<T> {
     }
     const { resource } = await this.container.item(itemId).delete<T>();
     return resource;
+  }
+
+  async getLastItem() {
+    const items = await this.find({
+      // query last incident by cosmos timestamp descending
+      query: 'SELECT TOP 1 * from c ORDER BY c._ts DESC'
+    });
+    return items?.[0];
   }
 }

--- a/src/db/DBConnector.ts
+++ b/src/db/DBConnector.ts
@@ -1,0 +1,69 @@
+// @ts-check
+import { Container, CosmosClient, Database, Resource, SqlQuerySpec } from "@azure/cosmos"
+
+export default class DBConnector<T> {
+
+  private client: CosmosClient;
+  private databaseId: string;
+  private collectionId: string;
+  private database: Database | null;
+  private container: Container | null;
+
+  /**
+   * Manages reading, adding, and updating Tasks in Cosmos DB
+   * @param {CosmosClient} cosmosClient
+   * @param {string} databaseId
+   * @param {string} containerId
+   */
+  constructor(cosmosClient: CosmosClient, databaseId: string, containerId: string) {
+    this.client = cosmosClient
+    this.databaseId = databaseId
+    this.collectionId = containerId
+
+    this.database = null
+    this.container = null
+  }
+
+  async init() {
+    const dbResponse = await this.client.databases.createIfNotExists({
+      id: this.databaseId
+    });
+    this.database = dbResponse.database;
+    const coResponse = await this.database.containers.createIfNotExists({
+      id: this.collectionId
+    })
+    this.container = coResponse.container;
+  }
+
+  async find(querySpec: string | SqlQuerySpec) {
+    if (!this.container) {
+      throw new Error('Collection is not initialized.')
+    }
+    const { resources } = await this.container.items.query<T>(querySpec).fetchAll()
+    return resources
+  }
+
+  async addItem(item: T) {
+    if (!this.container) {
+      throw new Error('Collection is not initialized.')
+    }
+    const { resource } = await this.container.items.create<T>(item)
+    return resource;
+  }
+
+  async getItem(itemId: string) {
+    if (!this.container) {
+      throw new Error('Collection is not initialized.')
+    }
+    const { resource } = await this.container.item(itemId).read<T>()
+    return resource
+  }
+  
+  async deleteItem(itemId: string) {
+    if (!this.container) {
+      throw new Error('Collection is not initialized.')
+    }
+    const { resource } = await this.container.item(itemId).delete<T>();
+    return resource;
+  }
+}

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { CacheType, CommandInteraction, CommandInteractionOptionResolver, Message, PartialMessage } from "discord.js";
+import { CommandInteraction, Message, PartialMessage } from "discord.js";
 
 
 //TODO - expand interface to have a 'canExecute' method to check args and return help message

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -8,7 +8,7 @@ export interface Command {
     adminOnly?: boolean;
     description: string;
     help?: string;
-    execute: (message: Message, args?: string[]) => void;
+    execute?: (message: Message, args?: string[]) => void;
     slashCommandDescription?:  () => Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">;
     executeSlashCommand?: (options:  CommandInteraction) => void;
 }

--- a/src/models/DBModels.ts
+++ b/src/models/DBModels.ts
@@ -10,4 +10,5 @@ export interface Incident {
     id?: string;
     occurrence: Date;
     note?: string;
+    link?: string;
 }

--- a/src/models/DBModels.ts
+++ b/src/models/DBModels.ts
@@ -5,3 +5,9 @@ export interface Award {
     awardedOn: Date;
     message?: string;
 }
+
+export interface Incident {
+    id?: string;
+    occurrence: Date;
+    note?: string;
+}

--- a/src/models/DBModels.ts
+++ b/src/models/DBModels.ts
@@ -1,0 +1,7 @@
+export interface Award {
+    id?: string;
+    awardedTo: string;
+    awardedBy: string;
+    awardedOn: Date;
+    message?: string;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -90,21 +90,23 @@ client.on('messageCreate', async (message) => {
 
     //bad bot
     if (message.author.bot) return;
+
+    const { channel, content } = message;
     
-    if (message.channel instanceof TextChannel && message?.channel?.id == ChannelIds.RANT) {
+    if (channel instanceof TextChannel && channel?.id == ChannelIds.RANT) {
         deleteMessages(message);
     }
     if (message.content === 'SEA') {
-        message.channel.send('HAWKS!')
+        channel.send('HAWKS!')
         return;
     }
-    if (message.content.toLowerCase().includes('tbf') || message.content.toLowerCase().includes('to be fair')) {
+    if (content.toLowerCase().includes('tbf') || content.toLowerCase().includes('to be fair')) {
         // we use tbf more than we should, tbf
         if (Math.random() >= 0.75) {
-            message.channel.send('https://tenor.com/view/letterkenny-to-be-tobefair-gif-14136631');
+            channel.send('https://tenor.com/view/letterkenny-to-be-tobefair-gif-14136631');
         }
     }
-    if (message.content.toLowerCase().includes('bisbopt')) {
+    if (content.toLowerCase().includes('bisbopt')) {
         message.react(Emoji.bisbopt);
     }
 
@@ -121,7 +123,7 @@ client.on('messageCreate', async (message) => {
     //send it
     try {
         if(command?.adminOnly && !message.member?.roles.cache.has(RoleIds.MOD)){
-            message.channel.send('nice try, loser');
+            channel.send('nice try, loser');
             return;
         }
         else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,8 +20,8 @@ import { googleReact, lmgtfyReact } from './commands/reactionCommands';
 import { exit } from 'process';
 import { CosmosClient } from '@azure/cosmos';
 import DBConnector from './db/DBConnector';
-import { Award } from './models/DBModels';
-import { GiveAwardCommand, ShowAwardsCommand } from './commands/databaseCommands';
+import { Award, Incident } from './models/DBModels';
+import { IncidentCommand } from './commands/databaseCommands';
 
 const client = new Client({
   intents: [
@@ -39,16 +39,7 @@ const cosmosClient = new CosmosClient({
     key: Environment.cosmosAuthKey
 });
 
-const awardConnector = new DBConnector<Award>(cosmosClient, Database.DATABASE_ID, Database.Containers.AWARDS)
-const incidentConnector = new DBConnector<Incident>(cosmosClient, Database.DATABASE_ID, Database.Containers.INCIDENTS)
-
-awardConnector.init()
-  .catch(err => {
-    console.error(err)
-    console.error(
-      'There was an error connecting to the award container.'
-    )
-});
+const incidentConnector = new DBConnector<Incident>(cosmosClient, Database.DATABASE_ID, Database.Containers.INCIDENTS);
 
 incidentConnector.init()
 .catch(err => {
@@ -215,18 +206,37 @@ const registerAllSlashCommands = async (client: Client) => {
             const command = commands[commandName];
             if(command?.slashCommandDescription) {
                 console.log(`adding ${command.name} slash command registration`)
-               slashCommands.push(command.slashCommandDescription().toJSON())
+                const desc = command.slashCommandDescription();
+                slashCommands.push(desc.toJSON());
             }
         }
-        console.log('all commands: ')
-        console.dir(slashCommands);
         const result = await rest.put(
             Routes.applicationGuildCommands(client.user!.id, guild.id),
             {
                 body: slashCommands
             }
-        )
+        );
         console.dir(result);
+        // TODO: sort out slash command permissions
+        // result.forEach(async res => {
+            //if nobody can access this
+            // if(!res.default_permission)
+            // {
+            //   //at least let mods access it
+            //   const permissions: ApplicationCommandPermissionData[] = [...SlashCommandRoleConfigs.MOD_ONLY];
+            //   // get the command by id
+            //   const cmd = await guild.commands.fetch(res.id);
+            //   // add our special perms
+            //   const permResult = await cmd?.permissions.set({ permissions });
+            //   if (permResult) {
+            //     console.log(
+            //       "Gave MOD access to the following command: " + res.name
+            //     );
+            //     console.dir(permResult);
+            //   }
+            // }
+        // });
+        
 
     });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,12 +40,21 @@ const cosmosClient = new CosmosClient({
 });
 
 const awardConnector = new DBConnector<Award>(cosmosClient, Database.DATABASE_ID, Database.Containers.AWARDS)
+const incidentConnector = new DBConnector<Incident>(cosmosClient, Database.DATABASE_ID, Database.Containers.INCIDENTS)
 
 awardConnector.init()
   .catch(err => {
     console.error(err)
     console.error(
       'There was an error connecting to the award container.'
+    )
+});
+
+incidentConnector.init()
+.catch(err => {
+    console.error(err)
+    console.error(
+      'There was an error connecting to the incident container.'
     )
 });
 
@@ -70,8 +79,7 @@ const commands: CommandDictionary = [
     RJSays,
     sarcasmText,
     whoopsCommand,
-    new GiveAwardCommand(awardConnector),
-    new ShowAwardsCommand(awardConnector)
+    new IncidentCommand(incidentConnector)
 ].reduce((map, obj) => {
     map[obj.name.toLowerCase()] = obj;
     return map;
@@ -144,7 +152,7 @@ client.on('messageCreate', async (message) => {
             channel.send('nice try, loser');
             return;
         }
-        else {
+        else if (command?.execute){
             command?.execute(message, args);
         }
     }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,6 @@
 import { SqlQuerySpec } from '@azure/cosmos';
+import { ApplicationCommandPermissionData } from 'discord.js';
+import { ApplicationCommandPermissionTypes } from 'discord.js/typings/enums';
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -6,6 +8,7 @@ export module Database {
     export const DATABASE_ID = 'seabot';
     export module Containers {
         export const AWARDS = 'Awards';
+        export const INCIDENTS = 'Incidents';
     }
     export module Queries {
         export const AWARDS_BY_USER = (userId: string): SqlQuerySpec => {
@@ -47,6 +50,7 @@ export module Config {
 }
 export module RoleIds {
     export const MOD = '370946173902520342';
+    export const EVERYONE = '370945003566006272';
 }
 export module ChannelIds {
     export const RANT = '804639001226379294';
@@ -157,4 +161,17 @@ export module ServerInfo {
         export const ipAddress = '20.57.179.81';
         export const access = process.env['valheim_server_password']
     }
+}
+
+export module SlashCommandRoleConfigs {
+    export const MOD_ONLY: ApplicationCommandPermissionData[] = [{
+            id: RoleIds.MOD,
+            type: ApplicationCommandPermissionTypes.ROLE,
+            permission: true,
+        },
+        {
+            id: RoleIds.EVERYONE,
+            type: ApplicationCommandPermissionTypes.ROLE,
+            permission: false,
+        }]
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,26 @@
+import { SqlQuerySpec } from '@azure/cosmos';
 import dotenv from 'dotenv';
 dotenv.config();
+
+export module Database {
+    export const DATABASE_ID = 'seabot';
+    export module Containers {
+        export const AWARDS = 'Awards';
+    }
+    export module Queries {
+        export const AWARDS_BY_USER = (userId: string): SqlQuerySpec => {
+            return {
+                query: 'SELECT * FROM Awards a where a.awardedTo = @userId',
+                parameters: [
+                    {
+                        name: '@userId',
+                        value: userId
+                    }
+                ]
+            }
+        }
+    }
+}
 
 export module Endpoints {
     export const currentWeatherURL = 'https://api.openweathermap.org/data/2.5/weather'
@@ -32,6 +53,8 @@ export module ChannelIds {
     export const VOICE_CREATE = '788552426906845185';
     export const USER_VOICE_GROUP = '788552301182320640';
     export const DEBUG = '541322708844281867';
+    export const GEOGUESSER = '370999118685798400';
+    export const MOD_LOG = '634526832816816128';
 }
 
 export module AppConfiguration {
@@ -115,6 +138,8 @@ export module Environment {
     export const hueAppId = process.env['hueAppId'] || undefined;
     export const hueClientSecret = process.env['hueClientSecret'] || undefined;
     export const hueState = process.env['hueState'] || undefined;
+    export const cosmosHost = process.env['cosmosHost'] || '';
+    export const cosmosAuthKey = process.env['cosmosAuthKey'] || '';
 }
 export module VoiceConstants {
     export const VOICE_TYPE = 2;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -57,7 +57,6 @@ export module ChannelIds {
     export const VOICE_CREATE = '788552426906845185';
     export const USER_VOICE_GROUP = '788552301182320640';
     export const DEBUG = '541322708844281867';
-    export const GEOGUESSER = '370999118685798400';
     export const MOD_LOG = '634526832816816128';
 }
 


### PR DESCRIPTION
This includes a new DB connection to an azure cosmos DB.

Currently there are two containers, one for `Awards` - feature still WIP, and the other for Incidents.

Mods can use `/incident new [note]` to record a new incident, and everyone can use `/incident last` to display how many days it's been since our last `incident`.

This PR still needs the following features:

- [x] Allow only mods to create new incidents
- [x] Ensure db can be modified externally to delete incidents
- [x] Allow addition of notes to incidents
- [x] Allow link to incident occurrence for easier browsing