### PR TITLE
add an autoreplacement that preserves message text besides links to the bad site

### DIFF
--- a/src/commands/messageContent/AutoReplace.ts
+++ b/src/commands/messageContent/AutoReplace.ts
@@ -1,0 +1,60 @@
+import { Message } from "discord.js";
+
+import ContentCommand from "./ContentCommand";
+
+type AutoReplaceCategory = {
+  name: string;
+  reason: string;
+  replacements: RegExp[];
+  combinedReplacement?: RegExp;
+}
+
+const autoReplaceStrings: AutoReplaceCategory[] = [
+  {
+    name: "twitter",
+    reason: "replacing links so we don't send traffic to the bad site:",
+    replacements: [
+      /twitter\.com/i,
+      /x\.com/i,
+      /girlcockx\.com/i,
+      /fixupx\.com/i,
+      /vxtwitter\.com/i,
+      /fxtwitter\.com/i,
+    ]
+  }
+];
+
+const mappedAutoReplaceStrings = autoReplaceStrings.map((category) => {
+  const newCategory = category
+  newCategory.combinedReplacement = new RegExp(
+    category.replacements.map((regex) => regex.source).join("|"),
+    "ig"
+  );
+  return newCategory;
+});
+
+const trigger = new RegExp(
+  [...mappedAutoReplaceStrings.map((category) => category.combinedReplacement?.source)]
+    .join("|"),
+  "i"
+);
+
+export default new ContentCommand({
+  name: "autoreact",
+  description:
+    "Automatically reacts to messages when a certain string or regex is triggered.",
+  trigger,
+  handler: (message: Message) => {
+    const content = message.content;
+    for (const category of mappedAutoReplaceStrings) {
+      if (category.combinedReplacement && category.combinedReplacement.test(content)) {
+        console.log(`${category.reason} ${category.name}`);
+        if (message.channel.isSendable()) {
+          message.channel.send(`Modifying <@${message.author.id}>'s message by ${category.reason}\n> ${message.content.replace(category.combinedReplacement, "xcancel.com").replace(/\n/g, "\n> ")}`);
+        }
+        message.delete();
+        return;
+      }
+    }
+  }
+});

--- a/src/commands/messageContent/index.ts
+++ b/src/commands/messageContent/index.ts
@@ -1,7 +1,8 @@
 import AutoRespond from "./AutoRespond";
+import AutoReplace from "./AutoReplace";
 import ContentCommand from "./ContentCommand";
 import DaysWithoutWordTracker from "./DaysWithoutWordTracker";
 
-const contentCommands: ContentCommand[] = [AutoRespond, DaysWithoutWordTracker];
+const contentCommands: ContentCommand[] = [AutoRespond, AutoReplace, DaysWithoutWordTracker];
 
 export default contentCommands;


### PR DESCRIPTION
[context](https://discord.com/channels/370945003566006272/1332108034020737024)

what I type:

<img width="655" height="93" alt="image" src="https://github.com/user-attachments/assets/c99f512a-abde-49a6-8b31-ab2e4c4456dc" />

when I send it, SEAbot will delete that message and replace it with the following:

<img width="1064" height="701" alt="image" src="https://github.com/user-attachments/assets/cdb5d1bc-638b-46dd-9b0f-e6f84666f921" />

all text besides the links to the bad site are preserved (in case the user writes three paragraphs of carefully thought out text as context). if multiple links to the bad site in a single message are included, they will all be replaced.

[xcancel](https://xcancel.com/) is an implementation of [Nitter](https://en.wikipedia.org/wiki/Nitter), a mirror of Twitter that doesn't send traffic to it directly.