### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/src/ExpressServer.ts
+++ b/src/ExpressServer.ts
@@ -51,6 +51,10 @@ export default class ExpressServer {
       Logger.error("Failed to initialize telemetry:", error);
     }
 
+    const rootRateLimit = rateLimit({
+      windowMs: 60 * 1000, // 1 minute
+      max: 30,             // limit each IP to 30 requests per window
+    });
     // TODO - make this a badass web page
     this._server.get("/", rootRateLimit, (_request, response) => {
       const uptime = process.uptime();

--- a/src/ExpressServer.ts
+++ b/src/ExpressServer.ts
@@ -52,7 +52,7 @@ export default class ExpressServer {
     }
 
     // TODO - make this a badass web page
-    this._server.get("/", (_request, response) => {
+    this._server.get("/", rootRateLimit, (_request, response) => {
       const uptime = process.uptime();
       const uptimeFormatted = formatUptime(uptime);
 
@@ -78,6 +78,15 @@ export default class ExpressServer {
       };
 
       response.json(buildInfo);
+    });
+
+    // Rate limiting for root endpoint
+    const rootRateLimit = rateLimit({
+      windowMs: 60 * 1000, // 1 minute window
+      max: 30, // 30 requests per window per IP
+      message: { error: "Too many requests to root endpoint, please slow down" },
+      standardHeaders: true,
+      legacyHeaders: false,
     });
 
     // Rate limiting for metrics endpoint


### PR DESCRIPTION
Potential fix for [https://github.com/reddit-seattle/seabot/security/code-scanning/4](https://github.com/reddit-seattle/seabot/security/code-scanning/4)

In general, to fix this kind of issue, attach a rate-limiting middleware to any route that performs potentially expensive operations (file system, DB, external services). This limits the number of requests an individual client can make in a given timeframe, mitigating denial-of-service risks while preserving normal functionality.

For this specific file, the best fix with minimal behavioral change is:

- Define a dedicated rate limiter for the `/` status/root endpoint, similar to the existing `metricsRateLimit`, but tuned for that route (e.g., slightly more generous as it’s a simple status/build-info endpoint).
- Attach this middleware to the `"/"` route by adding it as the second argument in `this._server.get("/", ...)`.
- Keep the rest of the handler logic unchanged so response format and behavior remain identical.

Concretely:

- In `src/ExpressServer.ts`, after the existing `metricsRateLimit` definition (or just before it), define a `rootRateLimit` (or similarly named) using `rateLimit(...)`.
- Modify the line that currently reads `this._server.get("/", (_request, response) => { ... })` so it becomes `this._server.get("/", rootRateLimit, (_request, response) => { ... })`.
- No new imports are needed, as `express-rate-limit` is already imported as `rateLimit`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
