### PR TITLE
Update pike place regex to include other quotes symbols

### DIFF
--- a/src/commands/messageContent/AutoRespond.ts
+++ b/src/commands/messageContent/AutoRespond.ts
@@ -31,7 +31,7 @@ const responseMap = new Map<string | RegExp, AutoResponse>([
   [/^SEA$/im, { message: "HAWKS!" }],
   [/(tbf|to be fair)/i, { message: Strings.letterkennyGif, chance: 0.33 }],
   [/(\s|^)eggs?/i, { reaction: "🥚", chance: 0.2 }],
-  [/pike['|`|"]?s['|`|"]? place/i, { message: "uh, pike* place tyvm", chance: 1 }],
+  [/pike['|`|"|`|'|‘|“|”]?s['|`|"|`|'|‘|“|”]? place/i, { message: "uh, pike* place tyvm", chance: 1 }],
 ]);
 
 function emojiFromName(emojiName: string, message: Message): GuildEmoji | null {

--- a/src/commands/messageContent/AutoRespond.ts
+++ b/src/commands/messageContent/AutoRespond.ts
@@ -31,7 +31,7 @@ const responseMap = new Map<string | RegExp, AutoResponse>([
   [/^SEA$/im, { message: "HAWKS!" }],
   [/(tbf|to be fair)/i, { message: Strings.letterkennyGif, chance: 0.33 }],
   [/(\s|^)eggs?/i, { reaction: "🥚", chance: 0.2 }],
-  [/pike[']?s[']? place/i, { message: "uh, pike* place tyvm", chance: 1 }],
+  [/pike['|`|"]?s['|`|"]? place/i, { message: "uh, pike* place tyvm", chance: 1 }],
 ]);
 
 function emojiFromName(emojiName: string, message: Message): GuildEmoji | null {


### PR DESCRIPTION
Added additional symbol checks in regex for other quotes usage for pike place autoreply. 

Per requested: https://discord.com/channels/370945003566006272/370945003566006274/1477558668906991616 